### PR TITLE
Pull requst for adding additional details Retrying failed tests configuration

### DIFF
--- a/thucydides.doc
+++ b/thucydides.doc
@@ -1580,7 +1580,7 @@ Another new experimental feature introduces the ability to replace the commonly-
 
 === Retrying failed tests
 
-Sometimes it is required to retry a failed test. This can be achieved by setting the system property +max.retries+ to the number of times you want failed tests to be retried.  
+Sometimes it is required to retry a failed test. This can be achieved by setting the system property +max.retries+ to the number of times you want failed tests to be retried. If +max.retries+ provided, all method tests will be executed until first successful run, but not more than 1 + +max.retries+ times.
 
 
 === Using Step methods to document test cases


### PR DESCRIPTION
Was added additional details to Retrying failed tests configuration.
new words:

"If +max.retries+ provided, all method tests will be executed until first successful run, but not more than 1 + +max.retries+ times."
